### PR TITLE
docs: Add 'How to Contribute' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ This is a starter to fast-track WordPress websites. It provides a way to skip ma
 | [CSS Class Reference](docs/css.md)              |
 | [Page Templates](docs/page-templates.md)        |
 | [Deployment](docs/deployment.md)                |
+| [How to Contribute](docs/contributing.md)       |
 
 ## SparkPress Team
+- **[Kasey Bonifacio](https://github.com/kaseybon)**
 - **[Ricardo Fearing](https://github.com/rfearing)**
 - **[Rob Tarr](https://github.com/robtarr)**
 - **[Philip Zastrow](https://github.com/zastrow/)**

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,52 @@
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -6,8 +6,8 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+nationality, personal appearance, race, religion, marital status, color or
+sex (including pregnancy, sexual orientation, or gender identity).
 
 ### Our Standards
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,18 @@
+# Contribute
+
+Hey! You're thinking about contributing? That's awesome! You're awesome. Don't know where to start? The best place to get started is visiting our [issues][issues] to see if there are any you'd like to tackle.
+
+Here's a few things you should know before you submit your PR:
+
+1. The purpose of this project is to make getting up and running on a WordPress project quick and simple. By design, it has minimal styles and functionality.
+1. Make sure any committed code follows the project's [style guide][styleguide].
+1. All contributions must follow our [code of conduct](code-of-conduct.md)
+
+## Contribution Workflow
+
+1. Fork and clone this repo.
+2. Make your changes on a [feature-branch](https://bocoup.com/weblog/git-workflow-walkthrough-feature-branches).
+3. Submit a Pull Request to the `main` branch.
+
+[styleguide]:https://github.com/sparkbox/sparkpress/blob/main/docs/development.md#linting
+[issues]:https://github.com/sparkbox/sparkpress/issues


### PR DESCRIPTION
### Added to documentation:
- How to contribute section
- Code of conduct section
- Added Kasey to the team listed